### PR TITLE
skip checking private/restricted IP ranges

### DIFF
--- a/class.geoswitch.php
+++ b/class.geoswitch.php
@@ -235,6 +235,15 @@ class GeoSwitch {
 	private static function get_record() {
 		if (is_null(self::$data_source))
 			return null;
+		// a hook to short-circuit IP checking.
+		if ( apply_filters( 'geoswitch_skip_ip_check', false, self::$user_ip ) ) {
+			return null;
+		}
+		
+		// skips checking for private/restricted IP addresses.
+		if ( ! filter_var( self::$user_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return null;
+		}
 		
 		try {
 			return self::$data_source->city(self::$user_ip);


### PR DESCRIPTION
Plugin currently throws an exception when working on local dev environment or via WP CLI due to private/restricted IPs not being in the database:
```
11-Jul-2018 09:50:43 UTC] exception 'GeoIp2\Exception\AddressNotFoundException' with message 'The address 10.172.25.25 is not in the database.' in /var/www/html/dev.example.com/wp-content/plugins/geoswitch/vendor/geoip2/geoip2/src/Database/Reader.php:244
Stack trace:
#0 /var/www/html/dev.example.com/wp-content/plugins/geoswitch/vendor/geoip2/geoip2/src/Database/Reader.php(215): GeoIp2\Database\Reader->getRecord('City', 'City', '10.172.25.25')
#1 /var/www/html/dev.example.com/wp-content/plugins/geoswitch/vendor/geoip2/geoip2/src/Database/Reader.php(71): GeoIp2\Database\Reader->modelFor('City', 'City', '10.172.25.25')
#2 /var/www/html/dev.example.com/wp-content/plugins/geoswitch/class.geoswitch.php(243): GeoIp2\Database\Reader->city('10.172.25.25')
#3 /var/www/html/dev.example.com/wp-content/plugins/geoswitch/class.geoswitch.php(34): GeoSwitch::get_record()
#4 [internal function]: GeoSwitch::init('')
#5 /var/www/html/dev.example.com/wp-includes/class-wp-hook.php(286): call_user_func_array(Array, Array)
#6 /var/www/html/dev.example.com/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#7 /var/www/html/dev.example.com/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#8 /var/www/html/dev.example.com/wp-settings.php(450): do_action('init')
#9 /var/www/html/dev.example.com/wp-config.php(50): require_once('/var/www/html/d...')
#10 /var/www/html/dev.example.com/wp-load.php(37): require_once('/var/www/html/d...')
#11 /var/www/html/dev.example.com/wp-blog-header.php(13): require_once('/var/www/html/d...')
#12 /var/www/html/dev.example.com/index.php(17): require('/var/www/html/d...')
#13 {main}
```
This PR proposes two changes:
1. a general `geoswitch_skip_ip_check` filter, which would allow developers to add custom checks on IP addresses and short-circuit ip check by passing `true` to this filter.
2. a specific check for private/restricted IP ranges.